### PR TITLE
Handling the Gateway Timeout Unmarshaling Error

### DIFF
--- a/druid.go
+++ b/druid.go
@@ -216,6 +216,11 @@ func defaultRetry(ctx context.Context, resp *http.Response, err error) (bool, er
 		return false, nil
 	}
 
+	switch resp.StatusCode {
+	case http.StatusGatewayTimeout:
+		return true, fmt.Errorf("gateway timeout")
+	}
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return true, fmt.Errorf("failed to read the response from Druid: %w", err)


### PR DESCRIPTION
There are some cases when Druid is having the gateway timeout with an HTTP 504 status code when the heavy requests take more than 1 minute to be processed. In this case the response is an HTML with a following payload:

```
<html>

<head>
    <title>504 Gateway Time-out</title>
</head>

<body>
    <center>
        <h1>504 Gateway Time-out</h1>
    </center>
</body>

</html>
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
```

This cannot be unmarshaled to the proper JSON structure making the error message unnecessarily long. So this case should be separately handled.