### PR TITLE
Add support for streaming response

### DIFF
--- a/query.go
+++ b/query.go
@@ -16,6 +16,8 @@ type QueryService struct {
 	client *Client
 }
 
+// Execute executes a query and returns the result.
+// Do not forget to close the response body if result is nil.
 func (q *QueryService) Execute(qry builder.Query, result interface{}, headers ...http.Header) (*Response, error) {
 	var path string
 	switch qry.Type() {


### PR DESCRIPTION
Previously, the entire response had to be loaded into memory before being sent. Now, if no result is provided, the content can be streamed without loading it all at once, improving efficiency for large data.