### PR TITLE
Support time column for first and last aggregations

### DIFF
--- a/builder/aggregation/double_first.go
+++ b/builder/aggregation/double_first.go
@@ -2,7 +2,8 @@ package aggregation
 
 type DoubleFirst struct {
 	Base
-	FieldName string `json:"fieldName,omitempty"`
+	FieldName  string `json:"fieldName,omitempty"`
+	TimeColumn string `json:"timeColumn,omitempty"`
 }
 
 func NewDoubleFirst() *DoubleFirst {
@@ -18,5 +19,10 @@ func (d *DoubleFirst) SetName(name string) *DoubleFirst {
 
 func (d *DoubleFirst) SetFieldName(fieldName string) *DoubleFirst {
 	d.FieldName = fieldName
+	return d
+}
+
+func (d *DoubleFirst) SetTimeColumn(timeColumn string) *DoubleFirst {
+	d.TimeColumn = timeColumn
 	return d
 }

--- a/builder/aggregation/double_last.go
+++ b/builder/aggregation/double_last.go
@@ -2,7 +2,8 @@ package aggregation
 
 type DoubleLast struct {
 	Base
-	FieldName string `json:"fieldName,omitempty"`
+	FieldName  string `json:"fieldName,omitempty"`
+	TimeColumn string `json:"timeColumn,omitempty"`
 }
 
 func NewDoubleLast() *DoubleLast {
@@ -19,4 +20,9 @@ func (d *DoubleLast) SetName(name string) *DoubleLast {
 func (d *DoubleLast) SetFieldName(fieldName string) *DoubleLast {
 	d.FieldName = fieldName
 	return d
+}
+
+func (l *DoubleLast) SetTimeColumn(timeColumn string) *DoubleLast {
+	l.TimeColumn = timeColumn
+	return l
 }

--- a/builder/aggregation/float_first.go
+++ b/builder/aggregation/float_first.go
@@ -2,7 +2,8 @@ package aggregation
 
 type FloatFirst struct {
 	Base
-	FieldName string `json:"fieldName,omitempty"`
+	FieldName  string `json:"fieldName,omitempty"`
+	TimeColumn string `json:"timeColumn,omitempty"`
 }
 
 func NewFloatFirst() *FloatFirst {
@@ -18,5 +19,10 @@ func (f *FloatFirst) SetName(name string) *FloatFirst {
 
 func (f *FloatFirst) SetFieldName(fieldName string) *FloatFirst {
 	f.FieldName = fieldName
+	return f
+}
+
+func (f *FloatFirst) SetTimeColumn(timeColumn string) *FloatFirst {
+	f.TimeColumn = timeColumn
 	return f
 }

--- a/builder/aggregation/float_last.go
+++ b/builder/aggregation/float_last.go
@@ -2,7 +2,8 @@ package aggregation
 
 type FloatLast struct {
 	Base
-	FieldName string `json:"fieldName,omitempty"`
+	FieldName  string `json:"fieldName,omitempty"`
+	TimeColumn string `json:"timeColumn,omitempty"`
 }
 
 func NewFloatLast() *FloatLast {
@@ -18,5 +19,10 @@ func (f *FloatLast) SetName(name string) *FloatLast {
 
 func (f *FloatLast) SetFieldName(fieldName string) *FloatLast {
 	f.FieldName = fieldName
+	return f
+}
+
+func (f *FloatLast) SetTimeColumn(timeColumn string) *FloatLast {
+	f.TimeColumn = timeColumn
 	return f
 }

--- a/builder/aggregation/long_first.go
+++ b/builder/aggregation/long_first.go
@@ -2,7 +2,8 @@ package aggregation
 
 type LongFirst struct {
 	Base
-	FieldName string `json:"fieldName,omitempty"`
+	FieldName  string `json:"fieldName,omitempty"`
+	TimeColumn string `json:"timeColumn,omitempty"`
 }
 
 func NewLongFirst() *LongFirst {
@@ -18,5 +19,10 @@ func (l *LongFirst) SetName(name string) *LongFirst {
 
 func (l *LongFirst) SetFieldName(fieldName string) *LongFirst {
 	l.FieldName = fieldName
+	return l
+}
+
+func (l *LongFirst) SetTimeColumn(timeColumn string) *LongFirst {
+	l.TimeColumn = timeColumn
 	return l
 }

--- a/builder/aggregation/long_last.go
+++ b/builder/aggregation/long_last.go
@@ -2,7 +2,8 @@ package aggregation
 
 type LongLast struct {
 	Base
-	FieldName string `json:"fieldName,omitempty"`
+	FieldName  string `json:"fieldName,omitempty"`
+	TimeColumn string `json:"timeColumn,omitempty"`
 }
 
 func NewLongLast() *LongLast {
@@ -18,5 +19,10 @@ func (l *LongLast) SetName(name string) *LongLast {
 
 func (l *LongLast) SetFieldName(fieldName string) *LongLast {
 	l.FieldName = fieldName
+	return l
+}
+
+func (l *LongLast) SetTimeColumn(timeColumn string) *LongLast {
+	l.TimeColumn = timeColumn
 	return l
 }

--- a/builder/aggregation/string_first.go
+++ b/builder/aggregation/string_first.go
@@ -4,6 +4,7 @@ type StringFirst struct {
 	Base
 	FieldName      string `json:"fieldName,omitempty"`
 	MaxStringBytes int64  `json:"maxStringBytes,omitempty"`
+	TimeColumn     string `json:"timeColumn,omitempty"`
 }
 
 func NewStringFirst() *StringFirst {
@@ -24,5 +25,10 @@ func (s *StringFirst) SetFieldName(fieldName string) *StringFirst {
 
 func (s *StringFirst) SetMaxStringBytes(maxStringBytes int64) *StringFirst {
 	s.MaxStringBytes = maxStringBytes
+	return s
+}
+
+func (s *StringFirst) SetTimeColumn(timeColumn string) *StringFirst {
+	s.TimeColumn = timeColumn
 	return s
 }

--- a/builder/aggregation/string_last.go
+++ b/builder/aggregation/string_last.go
@@ -4,6 +4,7 @@ type StringLast struct {
 	Base
 	FieldName      string `json:"fieldName,omitempty"`
 	MaxStringBytes int64  `json:"maxStringBytes,omitempty"`
+	TimeColumn     string `json:"timeColumn,omitempty"`
 }
 
 func NewStringLast() *StringLast {
@@ -24,5 +25,10 @@ func (s *StringLast) SetFieldName(fieldName string) *StringLast {
 
 func (s *StringLast) SetMaxStringBytes(maxStringBytes int64) *StringLast {
 	s.MaxStringBytes = maxStringBytes
+	return s
+}
+
+func (s *StringLast) SetTimeColumn(timeColumn string) *StringLast {
+	s.TimeColumn = timeColumn
 	return s
 }


### PR DESCRIPTION
Druid supports timeColumn on first and last aggregations: https://druid.apache.org/docs/latest/querying/aggregations/#first-and-last-aggregators. Adding support for it. 