### PR TITLE
Support thetaSketchEstimate post-aggregation type

### DIFF
--- a/builder/postaggregation/post_aggregator.go
+++ b/builder/postaggregation/post_aggregator.go
@@ -76,6 +76,8 @@ func Load(data []byte) (builder.PostAggregator, error) {
 		p = NewQuantilesDoublesSketchToCDF()
 	case "quantilesDoublesSketchToString":
 		p = NewQuantilesDoublesSketchToString()
+	case "thetaSketchEstimate":
+		p = NewThetaSketchEstimate()
 	case "":
 		return nil, errors.New("missing postaggregation type")
 	default:

--- a/builder/postaggregation/post_aggregator_test.go
+++ b/builder/postaggregation/post_aggregator_test.go
@@ -7,139 +7,155 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLoadInvalidJSON(t *testing.T) {
-	assert := assert.New(t)
-
-	f, err := Load([]byte("not JSON value"))
-
-	assert.Nilf(f, "post aggregation should be nil")
-	assert.Errorf(err, "loading should return a non-nil error")
-}
-
-func TestLoadUntypedJSON(t *testing.T) {
-	assert := assert.New(t)
-
-	f, err := Load([]byte("{}"))
-
-	assert.Nilf(f, "post aggregation should be nil")
-	assert.Errorf(err, "loading should return a non-nil error")
-}
-
-func TestLoadValidAggregation(t *testing.T) {
+func TestLoadAggregation(t *testing.T) {
 	tests := []struct {
 		name     string
 		jsonData string
 		expected builder.Aggregator
+		wantErr  assert.ErrorAssertionFunc
 	}{
+		{
+			name:     "empty json",
+			jsonData: "{}",
+			wantErr:  assert.Error,
+		},
+		{
+			name:     "invalid json",
+			jsonData: "not JSON value",
+			wantErr:  assert.Error,
+		},
 		{
 			name:     "arithmetic",
 			jsonData: `{"type":"arithmetic"}`,
 			expected: NewArithmetic().SetFields([]builder.PostAggregator{}),
+			wantErr:  assert.NoError,
 		},
 		{
 			name:     "constant",
 			jsonData: `{"type":"constant"}`,
 			expected: NewConstant(),
+			wantErr:  assert.NoError,
 		},
 		{
 			name:     "doubleGreatest",
 			jsonData: `{"type":"doubleGreatest"}`,
 			expected: NewDoubleGreatest().SetFields([]builder.PostAggregator{}),
+			wantErr:  assert.NoError,
 		},
 		{
 			name:     "doubleLeast",
 			jsonData: `{"type":"doubleLeast"}`,
 			expected: NewDoubleLeast().SetFields([]builder.PostAggregator{}),
+			wantErr:  assert.NoError,
 		},
 		{
 			name:     "expression",
 			jsonData: `{"type":"expression"}`,
 			expected: NewExpression(),
+			wantErr:  assert.NoError,
 		},
 		{
 			name:     "fieldAccess",
 			jsonData: `{"type":"fieldAccess"}`,
 			expected: NewFieldAccess(),
+			wantErr:  assert.NoError,
 		},
 		{
 			name:     "finalizingFieldAccess",
 			jsonData: `{"type":"finalizingFieldAccess"}`,
 			expected: NewFinalizingFieldAccess(),
+			wantErr:  assert.NoError,
 		},
 		{
 			name:     "hyperUniqueFinalizing",
 			jsonData: `{"type":"hyperUniqueFinalizing"}`,
 			expected: NewHyperUniqueFinalizing(),
+			wantErr:  assert.NoError,
 		},
 		{
 			name:     "javascript",
 			jsonData: `{"type":"javascript"}`,
 			expected: NewJavascript(),
+			wantErr:  assert.NoError,
 		},
 		{
 			name:     "longGreatest",
 			jsonData: `{"type":"longGreatest"}`,
 			expected: NewLongGreatest().SetFields([]builder.PostAggregator{}),
+			wantErr:  assert.NoError,
 		},
 		{
 			name:     "longLeast",
 			jsonData: `{"type":"longLeast"}`,
 			expected: NewLongLeast().SetFields([]builder.PostAggregator{}),
+			wantErr:  assert.NoError,
 		},
 		{
 			name:     "quantileFromTDigestSketch",
 			jsonData: `{"type":"quantileFromTDigestSketch"}`,
 			expected: NewQuantileFromTDigestSketch(),
+			wantErr:  assert.NoError,
 		},
 		{
 			name:     "quantilesFromTDigestSketch",
 			jsonData: `{"type":"quantilesFromTDigestSketch"}`,
 			expected: NewQuantilesFromTDigestSketch(),
+			wantErr:  assert.NoError,
 		},
 		{
 			name:     "quantilesDoublesSketchToQuantile",
 			jsonData: `{"type":"quantilesDoublesSketchToQuantile"}`,
 			expected: NewQuantilesDoublesSketchToQuantile(),
+			wantErr:  assert.NoError,
 		},
 		{
 			name:     "quantilesDoublesSketchToQuantiles",
 			jsonData: `{"type":"quantilesDoublesSketchToQuantiles"}`,
 			expected: NewQuantilesDoublesSketchToQuantiles(),
+			wantErr:  assert.NoError,
 		},
 		{
 			name:     "quantilesDoublesSketchToHistogram",
 			jsonData: `{"type":"quantilesDoublesSketchToHistogram"}`,
 			expected: NewQuantilesDoublesSketchToHistogram(),
+			wantErr:  assert.NoError,
 		},
 		{
 			name:     "quantilesDoublesSketchToRank",
 			jsonData: `{"type":"quantilesDoublesSketchToRank"}`,
 			expected: NewQuantilesDoublesSketchToRank(),
+			wantErr:  assert.NoError,
 		},
 		{
 			name:     "quantilesDoublesSketchToCDF",
 			jsonData: `{"type":"quantilesDoublesSketchToCDF"}`,
 			expected: NewQuantilesDoublesSketchToCDF(),
+			wantErr:  assert.NoError,
 		},
 		{
 			name:     "quantilesDoublesSketchToString",
 			jsonData: `{"type":"quantilesDoublesSketchToString"}`,
 			expected: NewQuantilesDoublesSketchToString(),
+			wantErr:  assert.NoError,
+		},
+		{
+			name:     "theta sketch estimate",
+			jsonData: `{"type": "thetaSketchEstimate"}`,
+			expected: NewThetaSketchEstimate(),
+			wantErr:  assert.NoError,
 		},
 		{
 			name:     "unknown post aggregator",
 			jsonData: `{"type": "blahblahType"}`,
 			expected: builder.NewSpec("blahblahType"),
+			wantErr:  assert.NoError,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert := assert.New(t)
-
-			a, err := Load([]byte(test.jsonData))
-
-			assert.NoErrorf(err, "loading a valid post aggregation should not fail")
-			assert.Equal(test.expected, a)
+			got, err := Load([]byte(test.jsonData))
+			test.wantErr(t, err)
+			assert.Equal(t, test.expected, got)
 		})
 	}
 }

--- a/builder/postaggregation/theta_sketch_estimate.go
+++ b/builder/postaggregation/theta_sketch_estimate.go
@@ -1,0 +1,33 @@
+package postaggregation
+
+// ThetaSketchEstimate is a post-aggregation that estimates the size of a theta sketch.
+// https://druid.apache.org/docs/latest/development/extensions-core/datasketches-theta#sketch-estimator
+type ThetaSketchEstimate struct {
+	Base
+	Field map[string]string `json:"field,omitempty"`
+}
+
+// NewThetaSketchEstimate creates a new instance of ThetaSketchEstimate.
+func NewThetaSketchEstimate() *ThetaSketchEstimate {
+	t := &ThetaSketchEstimate{}
+	t.SetType("thetaSketchEstimate")
+
+	return t
+}
+
+// SetName sets the name of the ThetaSketchEstimate.
+func (t *ThetaSketchEstimate) SetName(name string) *ThetaSketchEstimate {
+	t.Base.SetName(name)
+
+	return t
+}
+
+// SetField sets the field for the ThetaSketchEstimate.
+func (t *ThetaSketchEstimate) SetField(fieldName string) *ThetaSketchEstimate {
+	t.Field = map[string]string{
+		"type":      "fieldAccess",
+		"fieldName": fieldName,
+	}
+
+	return t
+}

--- a/builder/postaggregation/theta_sketch_estimate_test.go
+++ b/builder/postaggregation/theta_sketch_estimate_test.go
@@ -1,0 +1,46 @@
+package postaggregation
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestThetaSketchEstimate(t *testing.T) {
+	ts := NewThetaSketchEstimate().
+		SetName("testThetaSketchEstimate").
+		SetField("testFiledSketch")
+	raw := `
+		{
+		 "type": "thetaSketchEstimate",
+		 "name": "testThetaSketchEstimate",
+		 "field": {
+		   "type": "fieldAccess",
+		   "fieldName": "testFiledSketch"
+		 }
+		}
+	`
+
+	t.Run("build theta sketch estimate", func(t *testing.T) {
+		got, err := json.Marshal(ts)
+		assert.NoError(t, err)
+		assert.JSONEq(t, string(got), raw)
+	})
+
+	t.Run("load theta sketch estimate", func(t *testing.T) {
+		got, err := Load([]byte(raw))
+		assert.NoError(t, err)
+		assert.Equal(t, got, ts)
+	})
+
+	t.Run("round trip theta sketch estimate", func(t *testing.T) {
+		gotRaw, err := json.Marshal(ts)
+		assert.NoError(t, err)
+		assert.JSONEq(t, string(gotRaw), raw)
+
+		got, err := Load(gotRaw)
+		assert.NoError(t, err)
+		assert.Equal(t, got, ts)
+	})
+}


### PR DESCRIPTION
### Summary

This MR introduces support for the [thetaSketchEstimate](https://druid.apache.org/docs/latest/development/extensions-core/datasketches-theta/#theta-sketch-estimate-post-aggregator) post-aggregation type. This enables users to estimate cardinality from [thetaSketch](https://github.com/adjoeio/go-druid/blob/master/builder/aggregation/thetasketch.go) aggregation results using the builder API.

### Changes 
- Added new `ThetaSketchEstimate` type 
- Added new unit-tests for loading and building new type

### Testing 

- Manually tested against a druid cluster using a `timeseries` query
- Validated correct JSON output and results returned by the query